### PR TITLE
Add patient management navigation

### DIFF
--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -1,23 +1,30 @@
+import router from "@ohos.router";
 @Entry
 @Component
 struct Index {
   @State message: string = 'Hello World';
 
   build() {
-    RelativeContainer() {
+    Column() {
       Text(this.message)
         .id('HelloWorld')
         .fontSize($r('app.float.page_text_font_size'))
         .fontWeight(FontWeight.Bold)
-        .alignRules({
-          center: { anchor: '__container__', align: VerticalAlign.Center },
-          middle: { anchor: '__container__', align: HorizontalAlign.Center }
-        })
         .onClick(() => {
           this.message = 'Welcome';
+        })
+
+      Button('患者管理')
+        .id('PatientManageBtn')
+        .margin({ top: 20 })
+        .onClick(() => {
+          router.pushUrl({ url: 'pages/PatientManagement' })
         })
     }
     .height('100%')
     .width('100%')
+    .justifyContent(FlexAlign.Center)
+    .alignItems(HorizontalAlign.Center)
   }
 }
+

--- a/entry/src/main/ets/pages/PatientManagement.ets
+++ b/entry/src/main/ets/pages/PatientManagement.ets
@@ -1,0 +1,17 @@
+@Component
+struct PatientManagement {
+  build() {
+    Column() {
+      Text('患者管理页面')
+        .id('PatientManagementText')
+        .fontSize($r('app.float.page_text_font_size'))
+        .fontWeight(FontWeight.Bold)
+        .margin(20)
+    }
+    .width('100%')
+    .height('100%')
+    .justifyContent(FlexAlign.Center)
+    .alignItems(HorizontalAlign.Center)
+  }
+}
+

--- a/entry/src/main/resources/base/profile/main_pages.json
+++ b/entry/src/main/resources/base/profile/main_pages.json
@@ -1,5 +1,7 @@
 {
   "src": [
-    "pages/Index"
+    "pages/Index",
+    "pages/PatientManagement"
   ]
 }
+


### PR DESCRIPTION
## Summary
- add PatientManagement page
- add navigation to PatientManagement from Index page
- list PatientManagement page in profile

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68751214d6e083268c83598d3e999580