### PR TITLE
Fix missing Entry decorator

### DIFF
--- a/entry/src/main/ets/pages/PatientManagement.ets
+++ b/entry/src/main/ets/pages/PatientManagement.ets
@@ -1,3 +1,4 @@
+@Entry
 @Component
 struct PatientManagement {
   build() {


### PR DESCRIPTION
## Summary
- ensure PatientManagement page has a single `@Entry` decorator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687513c027188326b3c1e1a435ee9962