### PR TITLE
Enhance patient module UI

### DIFF
--- a/entry/src/main/ets/common/components/AvatarIcon.ets
+++ b/entry/src/main/ets/common/components/AvatarIcon.ets
@@ -1,0 +1,13 @@
+@Component
+export default struct AvatarIcon {
+  size: number = 40
+  src: string = ''
+
+  build() {
+    Image(this.src)
+      .width(this.size)
+      .height(this.size)
+      .borderRadius(this.size / 2)
+      .backgroundColor('#ddd')
+  }
+}

--- a/entry/src/main/ets/common/components/ListItemBasic.ets
+++ b/entry/src/main/ets/common/components/ListItemBasic.ets
@@ -1,0 +1,18 @@
+@Component
+export default struct ListItemBasic {
+  left: string = ''
+  right: string = ''
+  onClick: () => void = () => {}
+
+  build() {
+    Row() {
+      Text(this.left)
+      Spacer()
+      Text(this.right)
+    }
+    .padding({ left: 16, right: 16, top: 10, bottom: 10 })
+    .border({ width: 0, style: BorderStyle.Solid })
+    .borderBottom({ width: 1, color: '#eee' })
+    .onClick(this.onClick)
+  }
+}

--- a/entry/src/main/ets/common/components/SearchBar.ets
+++ b/entry/src/main/ets/common/components/SearchBar.ets
@@ -1,0 +1,17 @@
+@Component
+export default struct SearchBar {
+  placeholder: string = ''
+  onChange: (value: string) => void = () => {}
+  value: string = ''
+
+  build() {
+    Row() {
+      TextInput({ placeholder: this.placeholder, text: this.value })
+        .onChange((v: string) => this.onChange(v))
+        .backgroundColor('#f5f5f5')
+        .borderRadius(4)
+        .padding(8)
+        .width('100%')
+    }
+  }
+}

--- a/entry/src/main/ets/common/components/index.ts
+++ b/entry/src/main/ets/common/components/index.ts
@@ -1,0 +1,3 @@
+export { default as SearchBar } from './SearchBar'
+export { default as ListItemBasic } from './ListItemBasic'
+export { default as AvatarIcon } from './AvatarIcon'

--- a/entry/src/main/ets/model/patient.ts
+++ b/entry/src/main/ets/model/patient.ts
@@ -1,0 +1,21 @@
+export interface Patient {
+  id: number
+  name: string
+  gender: string
+  age: number
+  mobile: string
+  idCard: string
+  ssn: string
+  city: string
+  avatar: string
+  source: string
+  createTime: string
+}
+
+export interface Message {
+  id: number
+  title: string
+  content: string
+  createTime: string
+  receivers: number[]
+}

--- a/entry/src/main/ets/pages/Index.ets
+++ b/entry/src/main/ets/pages/Index.ets
@@ -18,7 +18,7 @@ struct Index {
         .id('PatientManageBtn')
         .margin({ top: 20 })
         .onClick(() => {
-          router.pushUrl({ url: 'pages/PatientManagement' })
+          router.pushUrl({ url: '/patient/home' })
         })
     }
     .height('100%')

--- a/entry/src/main/ets/pages/patient/MsgCreate.ets
+++ b/entry/src/main/ets/pages/patient/MsgCreate.ets
@@ -1,0 +1,33 @@
+import router from '@ohos.router'
+import { patientStore } from '../../store/patientStore'
+import { sendMessage } from '../../service/patientService'
+import promptAction from '@ohos.promptAction'
+import { ListItemBasic } from '../../common/components'
+
+@Component
+struct MsgCreate {
+  @State content: string = ''
+  @State count: number = 0
+
+  build() {
+    Column() {
+      TextInput({ placeholder: '输入消息', text: this.content })
+        .width('90%')
+        .onChange((v: string) => { this.content = v; this.count = v.length })
+      Text(`${this.count}/140`)
+      ListItemBasic({ left: '接收人', right: patientStore.selectedIds.length.toString() })
+        .onClick(() => router.pushUrl({ url: '/patient/receiverMode' }))
+      Button('发送')
+        .onClick(async () => {
+          if (this.content.length === 0 || this.content.length > 140 || patientStore.selectedIds.length === 0) {
+            return
+          }
+          await sendMessage({ content: this.content, receivers: patientStore.selectedIds })
+          promptAction.showToast({ message: '发送成功' })
+          router.replaceUrl({ url: '/patient/msgList' })
+        })
+    }
+    .width('100%')
+    .height('100%')
+  }
+}

--- a/entry/src/main/ets/pages/patient/MsgDetail.ets
+++ b/entry/src/main/ets/pages/patient/MsgDetail.ets
@@ -1,0 +1,22 @@
+import router from '@ohos.router'
+import { patientStore } from '../../store/patientStore'
+import { ListItemBasic } from '../../common/components'
+
+@Component
+struct MsgDetail {
+  build() {
+    let msg = patientStore.messages.find(m => m.id === Number(router.getParams().id))
+    Column() {
+      if (msg) {
+        Text(msg.title).fontSize(18)
+        Text(msg.createTime)
+        Text(msg.content)
+        ForEach(msg.receivers, (r: number) => {
+          ListItemBasic({ left: `接收人ID：${r}` })
+        })
+      }
+    }
+    .width('100%')
+    .height('100%')
+  }
+}

--- a/entry/src/main/ets/pages/patient/MsgList.ets
+++ b/entry/src/main/ets/pages/patient/MsgList.ets
@@ -1,0 +1,25 @@
+import router from '@ohos.router'
+import { patientStore } from '../../store/patientStore'
+import { SearchBar, ListItemBasic } from '../../common/components'
+
+@Component
+struct MsgList {
+  build() {
+    Column() {
+      SearchBar({
+        placeholder: '搜索',
+        onChange: () => {}
+      })
+        .margin({ bottom: 10 })
+      List() {
+        ForEach(patientStore.messages, (msg: any) => {
+          ListItemBasic({ left: msg.title })
+            .onClick(() => router.pushUrl({ url: `/patient/msgDetail?id=${msg.id}` }))
+        })
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .toolbar({ title: '消息列表', menu: [{ value: '新建', action: () => router.pushUrl({ url: '/patient/msgCreate' }) }] })
+  }
+}

--- a/entry/src/main/ets/pages/patient/PatientCategory.ets
+++ b/entry/src/main/ets/pages/patient/PatientCategory.ets
@@ -1,0 +1,28 @@
+import router from '@ohos.router'
+import { patientStore } from '../../store/patientStore'
+import { SearchBar, ListItemBasic } from '../../common/components'
+
+@Component
+struct PatientCategory {
+  build() {
+    Column() {
+      SearchBar({
+        placeholder: '搜索',
+        onChange: () => {}
+      })
+        .margin({ bottom: 10 })
+
+      List() {
+        ForEach(patientStore.patientsMap.get(router.getParams().type) || [], (item: any) => {
+          ListItemBasic({
+            left: item.name
+          })
+            .onClick(() => router.pushUrl({ url: `/patient/detail?id=${item.id}` }))
+        })
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .onAppear(() => patientStore.fetchPatients(router.getParams().type))
+  }
+}

--- a/entry/src/main/ets/pages/patient/PatientDetail.ets
+++ b/entry/src/main/ets/pages/patient/PatientDetail.ets
@@ -1,0 +1,28 @@
+import { getPatientDetail } from '../../service/patientService'
+import router from '@ohos.router'
+import type { Patient } from '../../model/patient'
+import { AvatarIcon } from '../../common/components'
+
+@Component
+struct PatientDetail {
+  @State patient: Patient | null = null
+
+  build() {
+    Column() {
+      if (this.patient) {
+        AvatarIcon({ src: this.patient.avatar, size: 60 })
+          .margin({ bottom: 10 })
+        Text(`姓名：${this.patient.name}`)
+        Text(`性别：${this.patient.gender}`)
+        Text(`年龄：${this.patient.age}`)
+        Text(`手机号：${this.patient.mobile}`)
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .onAppear(async () => {
+      const detail = await getPatientDetail(Number(router.getParams().id))
+      this.patient = detail
+    })
+  }
+}

--- a/entry/src/main/ets/pages/patient/PatientHome.ets
+++ b/entry/src/main/ets/pages/patient/PatientHome.ets
@@ -1,0 +1,39 @@
+import router from '@ohos.router'
+import { patientStore } from '../../store/patientStore'
+import { SearchBar, ListItemBasic } from '../../common/components'
+
+@Entry
+@Component
+struct PatientHome {
+  @State search: string = ''
+
+  private goto(source: string) {
+    router.pushUrl({ url: `/patient/category?type=${source}` })
+  }
+
+  build() {
+    Column() {
+      SearchBar({
+        placeholder: '搜索',
+        value: this.search,
+        onChange: (v: string) => { this.search = v }
+      })
+        .margin({ bottom: 10 })
+
+      Column() {
+        ListItemBasic({ left: '问诊' })
+          .onClick(() => this.goto('consult'))
+        ListItemBasic({ left: '挂号' })
+          .onClick(() => this.goto('register'))
+        ListItemBasic({ left: '开药' })
+          .onClick(() => this.goto('prescribe'))
+      }
+    }
+    .width('100%')
+    .height('100%')
+    .toolbar({
+      title: '患者管理',
+      menu: [{ value: '群发消息', action: () => router.pushUrl({ url: '/patient/msgList' }) }]
+    })
+  }
+}

--- a/entry/src/main/ets/pages/patient/ReceiverMode.ets
+++ b/entry/src/main/ets/pages/patient/ReceiverMode.ets
@@ -1,0 +1,20 @@
+import router from '@ohos.router'
+import { ListItemBasic } from '../../common/components'
+
+@Component
+struct ReceiverMode {
+  @State mode: string = 'all'
+
+  build() {
+    Column() {
+      ListItemBasic({ left: '全部' })
+        .onClick(() => { this.mode = 'all'; router.back() })
+      ListItemBasic({ left: '部分' })
+        .onClick(() => { this.mode = 'part'; router.pushUrl({ url: '/patient/receiverSelect?mode=part' }) })
+      ListItemBasic({ left: '不发给谁' })
+        .onClick(() => { this.mode = 'exclude'; router.pushUrl({ url: '/patient/receiverSelect?mode=exclude' }) })
+    }
+    .width('100%')
+    .height('100%')
+  }
+}

--- a/entry/src/main/ets/pages/patient/ReceiverSelect.ets
+++ b/entry/src/main/ets/pages/patient/ReceiverSelect.ets
@@ -1,0 +1,25 @@
+import router from '@ohos.router'
+import { patientStore } from '../../store/patientStore'
+import { SearchBar } from '../../common/components'
+
+@Component
+struct ReceiverSelect {
+  build() {
+    Column() {
+      SearchBar({ placeholder: '搜索', onChange: () => {} })
+        .margin({ bottom: 10 })
+      List() {
+        ForEach(patientStore.patientsMap.get('consult') || [], (p: any) => {
+          ListItem() {
+            Checkbox({ checked: patientStore.selectedIds.includes(p.id) })
+            Text(p.name)
+          }
+          .onClick(() => patientStore.toggleSelect(p.id))
+        })
+      }
+      Button('确定').onClick(() => router.back())
+    }
+    .width('100%')
+    .height('100%')
+  }
+}

--- a/entry/src/main/ets/service/patientService.ts
+++ b/entry/src/main/ets/service/patientService.ts
@@ -1,0 +1,28 @@
+import http from '@ohos.net.http';
+import type { Patient, Message } from '../model/patient';
+
+const BASE_URL = 'https://example.com/api';
+
+export function getPatientsBySource(source: 'consult' | 'register' | 'prescribe'): Promise<Patient[]> {
+  return http.fetch(`${BASE_URL}/patients?source=${source}`).then(resp => resp.json() as Promise<Patient[]>);
+}
+
+export function getPatientDetail(id: number): Promise<Patient> {
+  return http.fetch(`${BASE_URL}/patients/${id}`).then(resp => resp.json() as Promise<Patient>);
+}
+
+export function getMessages(): Promise<Message[]> {
+  return http.fetch(`${BASE_URL}/messages`).then(resp => resp.json() as Promise<Message[]>);
+}
+
+export function getMessage(id: number): Promise<Message> {
+  return http.fetch(`${BASE_URL}/messages/${id}`).then(resp => resp.json() as Promise<Message>);
+}
+
+export function sendMessage(payload: Partial<Message>): Promise<void> {
+  return http.fetch(`${BASE_URL}/messages`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  }).then(() => {});
+}

--- a/entry/src/main/ets/store/patientStore.ts
+++ b/entry/src/main/ets/store/patientStore.ts
@@ -1,0 +1,25 @@
+import { ObservableObject } from '@ohos/state';
+import type { Patient, Message } from '../model/patient';
+import { getPatientsBySource } from '../service/patientService';
+
+export class PatientStore extends ObservableObject {
+  patientsMap: Map<string, Patient[]> = new Map();
+  messages: Message[] = [];
+  selectedIds: number[] = [];
+
+  async fetchPatients(source: 'consult' | 'register' | 'prescribe'): Promise<void> {
+    const list = await getPatientsBySource(source);
+    this.patientsMap.set(source, list);
+  }
+
+  toggleSelect(id: number): void {
+    const idx = this.selectedIds.indexOf(id);
+    if (idx === -1) {
+      this.selectedIds.push(id);
+    } else {
+      this.selectedIds.splice(idx, 1);
+    }
+  }
+}
+
+export const patientStore = new PatientStore();

--- a/entry/src/main/resources/base/profile/main_pages.json
+++ b/entry/src/main/resources/base/profile/main_pages.json
@@ -1,7 +1,15 @@
 {
   "src": [
     "pages/Index",
-    "pages/PatientManagement"
+    "pages/PatientManagement",
+    "pages/patient/PatientHome",
+    "pages/patient/PatientCategory",
+    "pages/patient/PatientDetail",
+    "pages/patient/MsgList",
+    "pages/patient/MsgDetail",
+    "pages/patient/MsgCreate",
+    "pages/patient/ReceiverMode",
+    "pages/patient/ReceiverSelect"
   ]
 }
 


### PR DESCRIPTION
## Summary
- add reusable SearchBar, ListItemBasic and AvatarIcon components
- integrate common components into patient pages
- show Toast and redirect after sending a message

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6875157fffc483268a84a74d079c5be9