### PR TITLE
Fix compile error in MsgDetail page

### DIFF
--- a/entry/src/main/ets/pages/patient/MsgDetail.ets
+++ b/entry/src/main/ets/pages/patient/MsgDetail.ets
@@ -5,7 +5,7 @@ import { ListItemBasic } from '../../common/components'
 @Component
 struct MsgDetail {
   build() {
-    let msg = patientStore.messages.find(m => m.id === Number(router.getParams().id))
+    let msg = patientStore.messages.find(m => m.id === Number(router.getParams().id));
     Column() {
       if (msg) {
         Text(msg.title).fontSize(18)


### PR DESCRIPTION
## Summary
- fix syntax error in MsgDetail page

## Testing
- `npx hvigor` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68751a6cf6f883269f496f55dc864188