### PR TITLE
Fix MsgDetail build syntax

### DIFF
--- a/entry/src/main/ets/pages/patient/MsgDetail.ets
+++ b/entry/src/main/ets/pages/patient/MsgDetail.ets
@@ -6,7 +6,7 @@ import { ListItemBasic } from '../../common/components'
 struct MsgDetail {
   build() {
     let msg = patientStore.messages.find(m => m.id === Number(router.getParams().id));
-    Column() {
+    Column(() => {
       if (msg) {
         Text(msg.title).fontSize(18)
         Text(msg.createTime)
@@ -15,8 +15,8 @@ struct MsgDetail {
           ListItemBasic({ left: `接收人ID：${r}` })
         })
       }
-    }
-    .width('100%')
-    .height('100%')
+    })
+      .width('100%')
+      .height('100%')
   }
 }


### PR DESCRIPTION
## Summary
- adjust MsgDetail.ets build layout so it uses a valid JS arrow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68751c0ec92883269f8d9282c027bf7d