### PR TITLE
Fix hvigor parse error in MsgDetail component

### DIFF
--- a/entry/src/main/ets/pages/patient/MsgDetail.ets
+++ b/entry/src/main/ets/pages/patient/MsgDetail.ets
@@ -6,7 +6,7 @@ import { ListItemBasic } from '../../common/components'
 struct MsgDetail {
   build() {
     let msg = patientStore.messages.find(m => m.id === Number(router.getParams().id));
-    Column(() => {
+    Column() {
       if (msg) {
         Text(msg.title).fontSize(18)
         Text(msg.createTime)
@@ -15,8 +15,8 @@ struct MsgDetail {
           ListItemBasic({ left: `接收人ID：${r}` })
         })
       }
-    })
-      .width('100%')
-      .height('100%')
+    }
+    .width('100%')
+    .height('100%')
   }
 }


### PR DESCRIPTION
## Summary
- correct MsgDetail component syntax so hvigor rollup can parse

## Testing
- `tsc entry/src/main/ets/pages/patient/MsgDetail.ets --allowJs --noEmit` *(fails: unsupported `.ets` extension)*

------
https://chatgpt.com/codex/tasks/task_e_68751f1f33ec8326ae9c4fdfe2cfab90