### PR TITLE
Fix MsgDetail Column syntax

### DIFF
--- a/entry/src/main/ets/pages/patient/MsgDetail.ets
+++ b/entry/src/main/ets/pages/patient/MsgDetail.ets
@@ -17,6 +17,6 @@ struct MsgDetail {
       }
     }
     .width('100%')
-    .height('100%')
+    .height('100%');
   }
 }


### PR DESCRIPTION
## Summary
- ensure chained width/height ends with semicolon in MsgDetail

## Testing
- `npm run build` *(fails: could not find package.json)*
- `npx hvigor build` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687521484b408326a1ee1b06ea534d44