### PR TITLE
Fix ArkTS warnings

### DIFF
--- a/entry/src/main/ets/pages/PatientManagement.ets
+++ b/entry/src/main/ets/pages/PatientManagement.ets
@@ -1,4 +1,3 @@
-@Entry
 @Component
 struct PatientManagement {
   build() {

--- a/entry/src/main/ets/pages/patient/MsgDetail.ets
+++ b/entry/src/main/ets/pages/patient/MsgDetail.ets
@@ -21,7 +21,8 @@ struct MsgDetail {
     .width('100%')
     .height('100%')
     .onAppear(async () => {
-      this.msg = await getMessage(Number(router.getParams().id))
+      const { id } = router.getParams() as { id: string }
+      this.msg = await getMessage(Number(id))
     })
   }
 }

--- a/entry/src/main/ets/pages/patient/MsgList.ets
+++ b/entry/src/main/ets/pages/patient/MsgList.ets
@@ -1,6 +1,7 @@
 import router from '@ohos.router'
 import { patientStore } from '../../store/patientStore'
 import { SearchBar, ListItemBasic } from '../../common/components'
+import type { Message } from '../../model/patient'
 
 @Component
 struct MsgList {
@@ -12,7 +13,7 @@ struct MsgList {
       })
         .margin({ bottom: 10 })
       List() {
-        ForEach(patientStore.messages, (msg: any) => {
+        ForEach(patientStore.messages, (msg: Message) => {
           ListItemBasic({ left: msg.title })
             .onClick(() => router.pushUrl({ url: `/patient/msgDetail?id=${msg.id}` }))
         })

--- a/entry/src/main/ets/pages/patient/PatientCategory.ets
+++ b/entry/src/main/ets/pages/patient/PatientCategory.ets
@@ -1,6 +1,7 @@
 import router from '@ohos.router'
 import { patientStore } from '../../store/patientStore'
 import { SearchBar, ListItemBasic } from '../../common/components'
+import type { Patient } from '../../model/patient'
 
 @Component
 struct PatientCategory {
@@ -13,7 +14,8 @@ struct PatientCategory {
         .margin({ bottom: 10 })
 
       List() {
-        ForEach(patientStore.patientsMap.get(router.getParams().type) || [], (item: any) => {
+        const { type } = router.getParams() as { type: string }
+        ForEach(patientStore.patientsMap.get(type) || [], (item: Patient) => {
           ListItemBasic({
             left: item.name
           })
@@ -23,6 +25,9 @@ struct PatientCategory {
     }
     .width('100%')
     .height('100%')
-    .onAppear(() => patientStore.fetchPatients(router.getParams().type))
+    .onAppear(() => {
+      const { type } = router.getParams() as { type: string }
+      patientStore.fetchPatients(type)
+    })
   }
 }

--- a/entry/src/main/ets/pages/patient/PatientDetail.ets
+++ b/entry/src/main/ets/pages/patient/PatientDetail.ets
@@ -21,7 +21,8 @@ struct PatientDetail {
     .width('100%')
     .height('100%')
     .onAppear(async () => {
-      const detail = await getPatientDetail(Number(router.getParams().id))
+      const { id } = router.getParams() as { id: string }
+      const detail = await getPatientDetail(Number(id))
       this.patient = detail
     })
   }

--- a/entry/src/main/ets/pages/patient/PatientHome.ets
+++ b/entry/src/main/ets/pages/patient/PatientHome.ets
@@ -1,8 +1,6 @@
 import router from '@ohos.router'
 import { patientStore } from '../../store/patientStore'
 import { SearchBar, ListItemBasic } from '../../common/components'
-
-@Entry
 @Component
 struct PatientHome {
   @State search: string = ''

--- a/entry/src/main/ets/pages/patient/ReceiverSelect.ets
+++ b/entry/src/main/ets/pages/patient/ReceiverSelect.ets
@@ -1,6 +1,7 @@
 import router from '@ohos.router'
 import { patientStore } from '../../store/patientStore'
 import { SearchBar } from '../../common/components'
+import type { Patient } from '../../model/patient'
 
 @Component
 struct ReceiverSelect {
@@ -9,7 +10,7 @@ struct ReceiverSelect {
       SearchBar({ placeholder: '搜索', onChange: () => {} })
         .margin({ bottom: 10 })
       List() {
-        ForEach(patientStore.patientsMap.get('consult') || [], (p: any) => {
+        ForEach(patientStore.patientsMap.get('consult') || [], (p: Patient) => {
           ListItem() {
             Checkbox({ checked: patientStore.selectedIds.includes(p.id) })
             Text(p.name)


### PR DESCRIPTION
## Summary
- remove extra `@Entry` decorators
- use explicit types for patient messages and router parameters
- clean up `any` usage in ArkTS code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6876f9a1c35083268907fbb4a8bafd5e