### PR TITLE
Fix ArkTSCheck errors in PatientHome

### DIFF
--- a/entry/src/main/ets/pages/patient/PatientHome.ets
+++ b/entry/src/main/ets/pages/patient/PatientHome.ets
@@ -1,6 +1,7 @@
 import router from '@ohos.router'
 import { patientStore } from '../../store/patientStore'
 import { SearchBar, ListItemBasic } from '../../common/components'
+@Entry
 @Component
 struct PatientHome {
   @State search: string = ''


### PR DESCRIPTION
## Summary
- add missing @Entry decorator to PatientHome page

## Testing
- `npm install --silent @ohos/hypium@1.0.21 @ohos/hamock@1.0.0` *(fails: command not found or packages unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6876fd020d988326b99da46aa6687b4e