### PR TITLE
feat: fetch patient data from backend

### DIFF
--- a/entry/src/main/ets/pages/patient/huanzheguanli.ets
+++ b/entry/src/main/ets/pages/patient/huanzheguanli.ets
@@ -1,5 +1,5 @@
-//import { Router } from '@kit.ArkUI';
 import router from '@ohos.router';
+import { getPatientsBySource } from '../../service/patientService';
 class DividerTmp {
   strokeWidth: Length = 1;
   color: ResourceColor = '#ffe9f0f0';
@@ -20,11 +20,19 @@ struct Huanzheguanli {
   @State message: string = 'Hello World';
   @State searchText: string = '';
   @State egDivider: DividerTmp = new DividerTmp(1, '#ffe9f0f0');
-  private patientData: Array<Type1> = [
-    { title: '问诊患者', count: '20人', icon: $r('app.media.arrow_right') },
-    { title: '挂号患者', count: '13人', icon: $r('app.media.arrow_right') },
-    { title: '开药患者', count: '2人', icon: $r('app.media.arrow_right') }
-  ];
+  @State patientData: Array<Type1> = [];
+  async aboutToAppear() {
+    const [consult, register, prescribe] = await Promise.all([
+      getPatientsBySource('consult'),
+      getPatientsBySource('register'),
+      getPatientsBySource('prescribe')
+    ]);
+    this.patientData = [
+      { title: '问诊患者', count: `${consult.length}人`, icon: $r('app.media.arrow_right') },
+      { title: '挂号患者', count: `${register.length}人`, icon: $r('app.media.arrow_right') },
+      { title: '开药患者', count: `${prescribe.length}人`, icon: $r('app.media.arrow_right') }
+    ];
+  }
   build() {
     Column() {
       Row() {
@@ -99,13 +107,13 @@ struct Huanzheguanli {
               // 根据不同的列表项跳转到不同的页面
               switch (index) {
                 case 0:
-                  router.pushUrl({ url: 'pages/patient/huanzheliebiao' });
+                  router.pushUrl({ url: 'pages/patient/huanzheliebiao', params: { source: 'consult' } });
                   break;
                 case 1:
-                  router.pushUrl({ url: 'pages/patient/huanzheliebiao'});
+                  router.pushUrl({ url: 'pages/patient/huanzheliebiao', params: { source: 'register' } });
                   break;
                 case 2:
-                  router.pushUrl({ url: 'pages/patient/huanzheliebiao'});
+                  router.pushUrl({ url: 'pages/patient/huanzheliebiao', params: { source: 'prescribe' } });
                   break;
               }
             })
@@ -116,6 +124,3 @@ struct Huanzheguanli {
     }
   }
 }
-
-
-

--- a/entry/src/main/ets/pages/patient/huanzheliebiao.ets
+++ b/entry/src/main/ets/pages/patient/huanzheliebiao.ets
@@ -1,5 +1,6 @@
 import router from '@ohos.router';
 import image from '@ohos.multimedia.image';
+import { getPatientsBySource } from '../../service/patientService';
 class DividerTmp {
   strokeWidth: Length = 1;
   color: ResourceColor = '#ffe9f0f0';
@@ -10,6 +11,7 @@ class DividerTmp {
   }
 }
 interface type1{
+  id:number;
   img:Resource;
   name:string;
   gender:string;
@@ -24,27 +26,25 @@ struct Huanzheliebiao {
   @State message: string = 'Hello World';
   @State searchText: string = '';
   @State egDivider: DividerTmp = new DividerTmp(1, '#ffe9f0f0');
-  private patientlist:Array<type1>=
-    [{ img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-      { img:$r('app.media.img_3'),name:'李四',gender:'男',years:'43岁',lable:'视频问诊',text:'添加时间',time:'2020-04-03', },
-    ]
-
+  @State patientList:Array<type1> = [];
+  @State title: string = '';
+  async aboutToAppear() {
+    const params = router.getParams() as { source: 'consult' | 'register' | 'prescribe' };
+    const source = params?.source ?? 'consult';
+    const labelMap: Record<string, string> = { consult: '问诊患者', register: '挂号患者', prescribe: '开药患者' };
+    this.title = labelMap[source];
+    const list = await getPatientsBySource(source);
+    this.patientList = list.map(p => ({
+      id: p.id,
+      img: $r('app.media.img_3'),
+      name: p.name,
+      gender: p.gender === 'male' ? '男' : '女',
+      years: `${p.age}岁`,
+      lable: labelMap[p.source],
+      text: '添加时间',
+      time: p.createTime
+    }));
+  }
 
   build() {
     Column() {
@@ -54,7 +54,7 @@ struct Huanzheliebiao {
             .width(10)
             .height(30)
             .margin({ left: 10 })
-          Text('问诊患者')
+          Text(this.title)
             .fontSize(20)
             .fontWeight(600)
             .margin({ left: 10 })
@@ -89,7 +89,7 @@ Column(){
     .color('#E5E5E5').margin({top:10})
 }
       List() {
-        ForEach(this.patientlist, (item: type1, index) => {
+        ForEach(this.patientList, (item: type1, index) => {
           ListItem() {
             Row() {
               Image(item.img)
@@ -127,7 +127,7 @@ Column(){
             .padding(10)
             .backgroundColor('#FFFFFF')
             .onClick(() => {
-                  router.pushUrl({ url: 'pages/' });
+                  router.pushUrl({ url: 'pages/patient/huanzhexinxi', params: { id: item.id } });
               })
           }
         })

--- a/entry/src/main/ets/pages/patient/huanzhexinxi.ets
+++ b/entry/src/main/ets/pages/patient/huanzhexinxi.ets
@@ -1,3 +1,5 @@
+import router from '@ohos.router';
+import { getPatientDetail } from '../../service/patientService';
 class DividerTmp {
   strokeWidth: Length = 1;
   color: ResourceColor = '#ffe9f0f0';
@@ -15,16 +17,22 @@ interface Type1 {
 @Component
 struct Huanzhexinxi {
   @State message: string = 'Hello World';
-  private patientData: Array<Type1> = [
-    { title: '患者姓名', count: '李四'},
-    { title: '性别', count: '女' },
-    { title: '年龄', count: '32' },
-    { title: '电话号码', count: '188****1234' },
-    { title: '身份证号', count: '110101********0012' },
-    { title: '社保卡', count: '1201***9991' },
-    { title: '地区', count: '北京 朝阳区' },
-  ];
+  @State patientData: Array<Type1> = [];
   @State egDivider: DividerTmp = new DividerTmp(1, '#ffe9f0f0');
+  async aboutToAppear() {
+    const params = router.getParams() as { id: number };
+    const id = params?.id ?? 0;
+    const p = await getPatientDetail(id);
+    this.patientData = [
+      { title: '患者姓名', count: p.name},
+      { title: '性别', count: p.gender === 'male' ? '男' : '女' },
+      { title: '年龄', count: `${p.age}` },
+      { title: '电话号码', count: p.mobile },
+      { title: '身份证号', count: p.idCard },
+      { title: '社保卡', count: p.ssn },
+      { title: '地区', count: p.city },
+    ];
+  }
   build() {
     Column() {
       Row() {

--- a/entry/src/main/ets/pages/patient/xiaoxiliebiao.ets
+++ b/entry/src/main/ets/pages/patient/xiaoxiliebiao.ets
@@ -1,4 +1,5 @@
 import router from '@ohos.router';
+import { getMessages } from '../../service/patientService';
 class DividerTmp {
   strokeWidth: Length = 1;
   color: ResourceColor = '#ffe9f0f0';
@@ -21,17 +22,14 @@ struct Xiaoxiliebiao {
   @State message: string = 'Hello World';
   @State searchText: string = '';
   @State egDivider: DividerTmp = new DividerTmp(1, '#ffe9f0f0');
-private xiaoxilist:Array<type2>=[{title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-  {title:'停诊通知',content:'由于某种原因，原定于2020.0413日停诊......',img:$r('app.media.arrow_right'),date:'2020.04.13',time:'13:00:21'},
-]
+  @State xiaoxilist:Array<type2>=[];
+  async aboutToAppear() {
+    const list = await getMessages();
+    this.xiaoxilist = list.map(m => {
+      const parts = m.createTime.split(' ');
+      return { title: m.title, content: m.content, img: $r('app.media.arrow_right'), date: parts[0], time: parts[1] };
+    });
+  }
   build() {
     Column() {
       Row() {

--- a/entry/src/main/ets/service/patientService.ts
+++ b/entry/src/main/ets/service/patientService.ts
@@ -1,7 +1,7 @@
 import http from '@ohos.net.http';
 import type { Patient, Message } from '../model/patient';
 
-const BASE_URL = 'https://example.com/api';
+const BASE_URL = 'http://localhost:3000/api';
 
 export function getPatientsBySource(source: 'consult' | 'register' | 'prescribe'): Promise<Patient[]> {
   return http.fetch(`${BASE_URL}/patients?source=${source}`).then(resp => resp.json() as Promise<Patient[]>);

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,66 @@
+const express = require('express');
+const cors = require('cors');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const patients = [
+  { id: 1, name: '李四', gender: 'male', age: 43, mobile: '18800000001', idCard: '110101199001010011', ssn: 'SN001', city: '北京', avatar: '', source: 'consult', createTime: '2020-04-03 10:00:00' },
+  { id: 2, name: '王五', gender: 'female', age: 32, mobile: '18800000002', idCard: '110101199001010022', ssn: 'SN002', city: '上海', avatar: '', source: 'register', createTime: '2020-04-05 11:00:00' },
+  { id: 3, name: '赵六', gender: 'male', age: 25, mobile: '18800000003', idCard: '110101199001010033', ssn: 'SN003', city: '广州', avatar: '', source: 'prescribe', createTime: '2020-04-08 12:00:00' }
+];
+
+const messages = [
+  { id: 1, title: '停诊通知', content: '由于某种原因，原定于2020.04.13日停诊', createTime: '2020-04-13 13:00:21', receivers: [1, 2] },
+  { id: 2, title: '节日问候', content: '祝您身体健康，节日快乐', createTime: '2020-05-01 08:30:00', receivers: [2, 3] }
+];
+
+app.get('/api/patients', (req, res) => {
+  const { source } = req.query;
+  let result = patients;
+  if (source) {
+    result = patients.filter(p => p.source === source);
+  }
+  res.json(result);
+});
+
+app.get('/api/patients/:id', (req, res) => {
+  const patient = patients.find(p => p.id === Number(req.params.id));
+  if (patient) {
+    res.json(patient);
+  } else {
+    res.status(404).send();
+  }
+});
+
+app.get('/api/messages', (req, res) => {
+  res.json(messages);
+});
+
+app.get('/api/messages/:id', (req, res) => {
+  const msg = messages.find(m => m.id === Number(req.params.id));
+  if (msg) {
+    res.json(msg);
+  } else {
+    res.status(404).send();
+  }
+});
+
+app.post('/api/messages', (req, res) => {
+  const id = messages.length ? messages[messages.length - 1].id + 1 : 1;
+  const newMsg = {
+    id,
+    title: req.body.title || '',
+    content: req.body.content || '',
+    createTime: new Date().toISOString().replace('T', ' ').split('.')[0],
+    receivers: req.body.receivers || []
+  };
+  messages.push(newMsg);
+  res.status(201).json(newMsg);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "harmony-backend",
+  "version": "1.0.0",
+  "description": "Simple backend for Harmony project",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Express server to serve patient and message data
- switch patient pages from static data to backend fetches
- point service layer to local backend

## Testing
- `ohpm test` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689436a3deac8326b146ab8aa6d1ba4d