### PR TITLE
fix patient list title mapping and http request types

### DIFF
--- a/entry/src/main/ets/pages/patient/huanzheliebiao.ets
+++ b/entry/src/main/ets/pages/patient/huanzheliebiao.ets
@@ -42,8 +42,12 @@ struct Huanzheliebiao {
   async aboutToAppear() {
     const params = router.getParams() as SourceParams;
     const source = params?.source ?? 'consult';
-    const labelMap: LabelMap = { consult: '问诊患者', register: '挂号患者', prescribe: '开药患者' };
-    this.title = labelMap[source];
+    const labelMap: Map<string, string> = new Map([
+      ['consult', '问诊患者'],
+      ['register', '挂号患者'],
+      ['prescribe', '开药患者']
+    ]);
+    this.title = labelMap.get(source) ?? '';
     const list = await getPatientsBySource(source);
     this.patientList = list.map((p: Patient): type1 => ({
       id: p.id,
@@ -51,7 +55,7 @@ struct Huanzheliebiao {
       name: p.name,
       gender: p.gender === 'male' ? '男' : '女',
       years: `${p.age}岁`,
-      lable: labelMap[p.source],
+      lable: labelMap.get(p.source) ?? '',
       text: '添加时间',
       time: p.createTime
     }));

--- a/entry/src/main/ets/service/patientService.ts
+++ b/entry/src/main/ets/service/patientService.ts
@@ -3,19 +3,9 @@ import type { Patient, Message } from '../model/patient';
 
 const BASE_URL = 'http://localhost:3000/api';
 
-interface HeadersMap {
-  [key: string]: string;
-}
-
-interface RequestOptions {
-  method?: string;
-  header?: HeadersMap;
-  extraData?: string;
-}
-
-async function requestJson<T>(url: string, options: RequestOptions = {}): Promise<T> {
+async function requestJson<T>(url: string, options: http.HttpRequestOptions = {}): Promise<T> {
   const httpRequest = http.createHttp();
-  const response = await httpRequest.request(url, options);
+  const response: http.HttpResponse = await httpRequest.request(url, options);
   httpRequest.destroy();
   return JSON.parse(response.result as string) as T;
 }
@@ -36,10 +26,10 @@ export function getMessage(id: number): Promise<Message> {
   return requestJson<Message>(`${BASE_URL}/messages/${id}`);
 }
 
-export function sendMessage(payload: Partial<Message>): Promise<void> {
-  return requestJson<void>(`${BASE_URL}/messages`, {
-    method: 'POST',
+export async function sendMessage(payload: Partial<Message>): Promise<void> {
+  await requestJson<void>(`${BASE_URL}/messages`, {
+    method: http.RequestMethod.POST,
     header: { 'Content-Type': 'application/json' },
     extraData: JSON.stringify(payload)
-  }).then(() => {});
+  });
 }


### PR DESCRIPTION
## Summary
- avoid dynamic property indexing when setting patient list labels and title
- update HTTP helper to use platform types and request method constants

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68943be53100832693570721f132f1a7