### PR TITLE
fix: replace deprecated requestPermissions

### DIFF
--- a/entry/src/main/module.json5
+++ b/entry/src/main/module.json5
@@ -33,9 +33,9 @@
             ]
           }
         ],
-        "requestPermissions": [
-          { "name": "ohos.permission.INTERNET" },
-          { "name": "ohos.permission.GET_NETWORK_INFO" }
+        "permissions": [
+          "ohos.permission.INTERNET",
+          "ohos.permission.GET_NETWORK_INFO"
         ]
       }
     ],


### PR DESCRIPTION
## Summary
- use `permissions` array for EntryAbility instead of deprecated `requestPermissions`

## Testing
- `node hvigor/bin/hvigorw.js --help` *(fails: Cannot find module '/workspace/harmony_project/hvigor/bin/hvigorw.js')*
- `npx hvigor --help` *(fails: Not Found - GET https://registry.npmjs.org/hvigor)*


------
https://chatgpt.com/codex/tasks/task_e_68943fc8577c832698b839aa96134e89