### PR TITLE
feat: add patient search

### DIFF
--- a/entry/src/main/ets/pages/patient/huanzheliebiao.ets
+++ b/entry/src/main/ets/pages/patient/huanzheliebiao.ets
@@ -31,6 +31,12 @@ interface LabelMap {
   register: string;
   prescribe: string;
 }
+
+const labelMap: LabelMap = {
+  consult: '问诊患者',
+  register: '挂号患者',
+  prescribe: '开药患者'
+};
 @Entry
 @Component
 struct Huanzheliebiao {
@@ -39,26 +45,27 @@ struct Huanzheliebiao {
   @State egDivider: DividerTmp = new DividerTmp(1, '#ffe9f0f0');
   @State patientList:Array<type1> = [];
   @State title: string = '';
-  async aboutToAppear() {
-    const params = router.getParams() as SourceParams;
-    const source = params?.source ?? 'consult';
-    const labelMap: Map<string, string> = new Map([
-      ['consult', '问诊患者'],
-      ['register', '挂号患者'],
-      ['prescribe', '开药患者']
-    ]);
-    this.title = labelMap.get(source) ?? '';
-    const list = await getPatientsBySource(source);
+  @State source: 'consult' | 'register' | 'prescribe' = 'consult';
+
+  async loadPatients() {
+    const list = await getPatientsBySource(this.source, this.searchText);
     this.patientList = list.map((p: Patient): type1 => ({
       id: p.id,
       img: $r('app.media.img_3'),
       name: p.name,
       gender: p.gender === 'male' ? '男' : '女',
       years: `${p.age}岁`,
-      lable: labelMap.get(p.source) ?? '',
+      lable: labelMap[p.source],
       text: '添加时间',
       time: p.createTime
     }));
+  }
+
+  async aboutToAppear() {
+    const params = router.getParams() as SourceParams;
+    this.source = params?.source ?? 'consult';
+    this.title = labelMap[this.source];
+    await this.loadPatients();
   }
 
   build() {
@@ -85,8 +92,16 @@ struct Huanzheliebiao {
         Search({
           placeholder: '搜索患者',
           value: this.searchText
-        }).backgroundColor('#FFFFFF')
-          .borderWidth(0.1).placeholderFont({ size: 15, weight: 300 })
+        })
+          .backgroundColor('#FFFFFF')
+          .borderWidth(0.1)
+          .placeholderFont({ size: 15, weight: 300 })
+          .onChange((value: string) => {
+            this.searchText = value;
+          })
+          .onSubmit(() => {
+            this.loadPatients();
+          })
       }.width('80%').justifyContent(FlexAlign.Center).height('10%')
 
       Column() {

--- a/entry/src/main/ets/service/patientService.ts
+++ b/entry/src/main/ets/service/patientService.ts
@@ -52,13 +52,14 @@ export async function requestJson<T>(
 }
 
 export async function getPatientsBySource(
-  source: 'consult' | 'register' | 'prescribe'
+  source: 'consult' | 'register' | 'prescribe',
+  keyword: string = ''
 ): Promise<Patient[]> {
   try {
     // ① 发送请求
-    const list = await requestJson<Patient[]>(
-      `${BASE_URL}/patients?source=${source}`
-    );
+    const url = `${BASE_URL}/patients?source=${source}` +
+      (keyword ? `&keyword=${encodeURIComponent(keyword)}` : '');
+    const list = await requestJson<Patient[]>(url);
 
     // ② 成功日志
     console.info('AppLog', `getPatientsBySource 成功 (${source})`, list);

--- a/server/index.js
+++ b/server/index.js
@@ -17,10 +17,19 @@ const messages = [
 ];
 
 app.get('/api/patients', (req, res) => {
-  const { source } = req.query;
+  const { source, keyword } = req.query;
   let result = patients;
   if (source) {
-    result = patients.filter(p => p.source === source);
+    result = result.filter(p => p.source === source);
+  }
+  if (keyword) {
+    const kw = String(keyword);
+    result = result.filter(p =>
+      p.name.includes(kw) ||
+      p.mobile.includes(kw) ||
+      p.idCard.includes(kw) ||
+      p.ssn.includes(kw)
+    );
   }
   res.json(result);
 });


### PR DESCRIPTION
## Summary
- add keyword filter to patient API
- support keyword parameter in patient service
- integrate search box to request filtered patient list

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd server && npm test)` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68944fe606c083268b017e766cb2ca18