### PR TITLE
Fix patient search results aggregation without spread operator

### DIFF
--- a/entry/src/main/ets/pages/patient/huanzheguanli.ets
+++ b/entry/src/main/ets/pages/patient/huanzheguanli.ets
@@ -28,12 +28,12 @@ struct Huanzheguanli {
       this.searchResults = [];
       return;
     }
-    const lists = await Promise.all([
+    const lists: Patient[][] = await Promise.all([
       getPatientsBySource('consult', this.searchText),
       getPatientsBySource('register', this.searchText),
       getPatientsBySource('prescribe', this.searchText)
     ]);
-    this.searchResults = ([] as Patient[]).concat(...lists);
+    this.searchResults = lists.reduce((acc: Patient[], cur: Patient[]) => acc.concat(cur), []);
   }
   async aboutToAppear() {
     const results = await Promise.all([


### PR DESCRIPTION
## Summary
- Replace spread operator when aggregating patient search results to comply with ArkTS restrictions

## Testing
- `npx hvigor build` *(fails: 404 Not Found: hvigor@*)*

------
https://chatgpt.com/codex/tasks/task_e_6894564900188326938633969fe478e8