### PR TITLE
feat: add patient creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+**/node_modules
 /oh_modules
 /local.properties
 /.idea
@@ -10,3 +11,4 @@
 /.clang-tidy
 **/.test
 /.appanalyzer
+**/package-lock.json

--- a/entry/src/main/ets/pages/patient/huanzheguanli.ets
+++ b/entry/src/main/ets/pages/patient/huanzheguanli.ets
@@ -63,13 +63,22 @@ struct Huanzheguanli {
           .fontWeight(600)
           .margin({left:10})
         }
-        Text('群发消息')
-          .fontColor('#0062FF')
-          .fontSize(16)
-          .margin({right:10})
-          .onClick(()=>{
-            router.pushUrl({url:'pages/patient/xiaoxiliebiao'})
-          })
+        Row(){
+          Text('新建患者')
+            .fontColor('#0062FF')
+            .fontSize(16)
+            .margin({right:20})
+            .onClick(()=>{
+              router.pushUrl({url:'pages/patient/xinjianhuanzhe'})
+            })
+          Text('群发消息')
+            .fontColor('#0062FF')
+            .fontSize(16)
+            .margin({right:10})
+            .onClick(()=>{
+              router.pushUrl({url:'pages/patient/xiaoxiliebiao'})
+            })
+        }
       }.justifyContent(FlexAlign.SpaceBetween).width('100%')
       Divider()
         .width('100%')

--- a/entry/src/main/ets/pages/patient/xinjianhuanzhe.ets
+++ b/entry/src/main/ets/pages/patient/xinjianhuanzhe.ets
@@ -1,0 +1,81 @@
+import router from '@ohos.router';
+import { createPatient } from '../../service/patientService';
+
+@Entry
+@Component
+struct Xinjianhuanzhe {
+  @State name: string = '';
+  @State mobile: string = '';
+  @State source: 'consult' | 'register' | 'prescribe' = 'consult';
+
+  async submit() {
+    await createPatient({
+      name: this.name,
+      mobile: this.mobile,
+      source: this.source
+    });
+    router.back();
+  }
+
+  build() {
+    Column() {
+      Row() {
+        Text('返回')
+          .onClick(() => {
+            router.back();
+          })
+        Text('新建患者')
+          .fontSize(20)
+          .fontWeight(600)
+          .margin({ left: 10 })
+      }
+      .width('100%')
+      .justifyContent(FlexAlign.Start)
+      .height('8%')
+
+      TextInput({
+        placeholder: '姓名',
+        text: this.name
+      })
+        .margin({ top: 20, left: 20, right: 20 })
+        .onChange((value: string) => {
+          this.name = value;
+        })
+
+      TextInput({
+        placeholder: '手机号',
+        text: this.mobile
+      })
+        .margin({ top: 20, left: 20, right: 20 })
+        .onChange((value: string) => {
+          this.mobile = value;
+        })
+
+      Row() {
+        Button('问诊患者')
+          .onClick(() => {
+            this.source = 'consult';
+          })
+        Button('挂号患者')
+          .margin({ left: 10 })
+          .onClick(() => {
+            this.source = 'register';
+          })
+        Button('开药患者')
+          .margin({ left: 10 })
+          .onClick(() => {
+            this.source = 'prescribe';
+          })
+      }
+      .margin({ top: 20, left: 20, right: 20 })
+      .justifyContent(FlexAlign.Center)
+
+      Button('保存')
+        .margin({ top: 40, left: 20, right: 20 })
+        .onClick(() => {
+          this.submit();
+        })
+    }
+  }
+}
+

--- a/entry/src/main/ets/service/patientService.ts
+++ b/entry/src/main/ets/service/patientService.ts
@@ -96,3 +96,11 @@ export async function sendMessage(payload: Partial<Message>): Promise<void> {
     extraData: JSON.stringify(payload)
   });
 }
+
+export async function createPatient(payload: Partial<Patient>): Promise<Patient> {
+  return await requestJson<Patient>(`${BASE_URL}/patients`, {
+    method: http.RequestMethod.POST,
+    header: { 'Content-Type': 'application/json' },
+    extraData: JSON.stringify(payload)
+  });
+}

--- a/entry/src/main/resources/base/profile/main_pages.json
+++ b/entry/src/main/resources/base/profile/main_pages.json
@@ -4,7 +4,8 @@
     "pages/patient/xiaoxiliebiao",
     "pages/patient/huanzheliebiao",
     "pages/patient/huanzhexinxi",
-    "pages/patient/huanzheguanli"
+    "pages/patient/huanzheguanli",
+    "pages/patient/xinjianhuanzhe"
   ]
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,25 @@ const messages = [
   { id: 2, title: '节日问候', content: '祝您身体健康，节日快乐', createTime: '2020-05-01 08:30:00', receivers: [2, 3] }
 ];
 
+app.post('/api/patients', (req, res) => {
+  const id = patients.length ? patients[patients.length - 1].id + 1 : 1;
+  const newPatient = {
+    id,
+    name: req.body.name || '',
+    gender: req.body.gender || 'male',
+    age: req.body.age || 0,
+    mobile: req.body.mobile || '',
+    idCard: req.body.idCard || '',
+    ssn: req.body.ssn || '',
+    city: req.body.city || '',
+    avatar: req.body.avatar || '',
+    source: req.body.source || 'consult',
+    createTime: new Date().toISOString().replace('T', ' ').split('.')[0]
+  };
+  patients.push(newPatient);
+  res.status(201).json(newPatient);
+});
+
 app.get('/api/patients', (req, res) => {
   const { source, keyword } = req.query;
   let result = patients;


### PR DESCRIPTION
## Summary
- add API and client service for creating patients
- add patient creation page and navigation

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd server && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68945f82708c832680cea765058d7fac