### PR TITLE
style: highlight selected state in new patient page buttons

### DIFF
--- a/entry/src/main/ets/pages/patient/xinjianhuanzhe.ets
+++ b/entry/src/main/ets/pages/patient/xinjianhuanzhe.ets
@@ -65,11 +65,17 @@ struct Xinjianhuanzhe {
 
       Row() {
         Button('男')
+          .fontColor(this.gender === 'male' ? Color.White : Color.Black)
+          .backgroundColor(this.gender === 'male' ? Color.Blue : Color.White)
+          .border({ width: 1, color: Color.Blue })
           .onClick(() => {
             this.gender = 'male';
           })
         Button('女')
           .margin({ left: 10 })
+          .fontColor(this.gender === 'female' ? Color.White : Color.Black)
+          .backgroundColor(this.gender === 'female' ? Color.Blue : Color.White)
+          .border({ width: 1, color: Color.Blue })
           .onClick(() => {
             this.gender = 'female';
           })
@@ -115,16 +121,25 @@ struct Xinjianhuanzhe {
 
       Row() {
         Button('问诊患者')
+          .fontColor(this.source === 'consult' ? Color.White : Color.Black)
+          .backgroundColor(this.source === 'consult' ? Color.Blue : Color.White)
+          .border({ width: 1, color: Color.Blue })
           .onClick(() => {
             this.source = 'consult';
           })
         Button('挂号患者')
           .margin({ left: 10 })
+          .fontColor(this.source === 'register' ? Color.White : Color.Black)
+          .backgroundColor(this.source === 'register' ? Color.Blue : Color.White)
+          .border({ width: 1, color: Color.Blue })
           .onClick(() => {
             this.source = 'register';
           })
         Button('开药患者')
           .margin({ left: 10 })
+          .fontColor(this.source === 'prescribe' ? Color.White : Color.Black)
+          .backgroundColor(this.source === 'prescribe' ? Color.Blue : Color.White)
+          .border({ width: 1, color: Color.Blue })
           .onClick(() => {
             this.source = 'prescribe';
           })
@@ -134,6 +149,9 @@ struct Xinjianhuanzhe {
 
       Button('保存')
         .margin({ top: 40, left: 20, right: 20 })
+        .fontColor(Color.Black)
+        .backgroundColor(Color.White)
+        .border({ width: 1, color: Color.Blue })
         .onClick(() => {
           this.submit();
         })


### PR DESCRIPTION
## Summary
- Style gender and patient source buttons with black text, white background, and blue border
- Highlight selected buttons with blue background and white text to reflect single-choice state
- Apply consistent styling to the save button

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/harmony_project/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6894657b53648326b4469643b3d14b8d